### PR TITLE
チケット用のフィルターの改修

### DIFF
--- a/app/admin/stages.rb
+++ b/app/admin/stages.rb
@@ -12,14 +12,13 @@ ActiveAdmin.register Stage do
 #   permitted
 # end
 
-permit_params :performance, :total, :sold
+permit_params :performance, :total
 
   index do
     selectable_column
     id_column
     column :performance
     column :total
-    column :sold
     column :deadline #この行をを追加しました(2019/1/22)
     column :end_flag #この行をを追加しました(2019/1/22)
     actions
@@ -27,7 +26,6 @@ permit_params :performance, :total, :sold
 
   filter :performance
   filter :total
-  filter :sold
   filter :deadline #この行をを追加しました(2019/1/22)
   filter :end_flag #この行をを追加しました(2019/1/22)
 
@@ -35,7 +33,6 @@ permit_params :performance, :total, :sold
     f.inputs do
       f.input :performance
       f.input :total
-      f.input :sold
       f.input :deadline #この行をを追加しました(2019/1/22)
       f.input :end_flag #この行をを追加しました(2019/1/22)
     end

--- a/app/admin/tickets.rb
+++ b/app/admin/tickets.rb
@@ -35,9 +35,9 @@ index do
     actions
   end
 
-    filter :user_name, as: :string, label: User.human_attribute_name(:name)
-    filter :stage_performance, as: :string, label: Stage.human_attribute_name(:performance)
-    filter :type_kind, as: :string, label: Type.human_attribute_name(:kind)
+    filter :user_name, label: User.human_attribute_name(:name), as: :select, collection: User.pluck(:name)
+    filter :stage_performance, label: Stage.human_attribute_name(:performance), as: :select, collection: Stage.pluck(:performance)
+    filter :type_kind, label: Type.human_attribute_name(:kind), as: :select, collection: Type.pluck(:kind)
     # filter :count コメント化しました(2019/1/22)
     filter :b_name
     # filter :b_mail コメント化しました(2019/1/22)

--- a/app/admin/tickets.rb
+++ b/app/admin/tickets.rb
@@ -35,9 +35,9 @@ index do
     actions
   end
 
-    filter :user_name, as: :string
-    filter :stage_performance, as: :string
-    filter :type_kind, as: :string
+    filter :user_name, as: :string, label: User.human_attribute_name(:name)
+    filter :stage_performance, as: :string, label: Stage.human_attribute_name(:performance)
+    filter :type_kind, as: :string, label: Type.human_attribute_name(:kind)
     # filter :count コメント化しました(2019/1/22)
     filter :b_name
     # filter :b_mail コメント化しました(2019/1/22)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,9 +5,9 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-User.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password') if Rails.env.development?
-User.create!(email: 'puente.japan@gmail.com', password: 'orangeseed69', password_confirmation: 'orangeseed69') if Rails.env.development?
-User.create!(email: 'puente.japan2@gmail.com', password: 'orangeseed69', password_confirmation: 'orangeseed69') if Rails.env.development?
-User.create!(email: 'puente.japan3@gmail.com', password: 'orangeseed69', password_confirmation: 'orangeseed69') if Rails.env.development?
-User.create!(email: 'puente.japan4@gmail.com', password: 'orangeseed69', password_confirmation: 'orangeseed69') if Rails.env.development?
-User.create!(email: 'puente.japan5@gmail.com', password: 'orangeseed69', password_confirmation: 'orangeseed69') if Rails.env.development?
+User.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password', name: '0') if Rails.env.development?
+User.create!(email: 'puente.japan@gmail.com', password: 'orangeseed69', password_confirmation: 'orangeseed69', name: '1') if Rails.env.development?
+User.create!(email: 'puente.japan2@gmail.com', password: 'orangeseed69', password_confirmation: 'orangeseed69', name: '2') if Rails.env.development?
+User.create!(email: 'puente.japan3@gmail.com', password: 'orangeseed69', password_confirmation: 'orangeseed69', name: '3') if Rails.env.development?
+User.create!(email: 'puente.japan4@gmail.com', password: 'orangeseed69', password_confirmation: 'orangeseed69', name: '4') if Rails.env.development?
+User.create!(email: 'puente.japan5@gmail.com', password: 'orangeseed69', password_confirmation: 'orangeseed69', name: '5') if Rails.env.development?


### PR DESCRIPTION
- seedがuserのvalidationに弾かれるようになっていたため対処しました。(値は適当であるため、適宜修正をお願いします。)
- soldというカラムのremoveに伴い、登録ができなくなっていたため、是正
- チケットのフィルター部分の日本語を修正
- チケットのフィルター部分のいち部をselect box化