### PR TITLE
不具合・要望対応

### DIFF
--- a/app/admin/tickets.rb
+++ b/app/admin/tickets.rb
@@ -49,6 +49,7 @@ index do
       if current_user.admin?
         f.input :user_id, as: :select, collection: User.pluck(:name, :id).to_h #nameを入力必須にしたので、pluck内の『:email』を『:name』に変更しました。(2019/1/22)
       else
+        f.input :user_name, input_html: { value: current_user.name, disabled: true }
         f.input :user_id, input_html: { value: current_user.id }, as: :hidden
       end
       f.input :stage_id, as: :select, collection: Stage.pluck(:performance, :id).to_h

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,6 +8,7 @@ class Ability
     else
       # Ticketは、自身のものだけは管理できる
       can :manage, Ticket, user: user
+      can :read, ActiveAdmin::Page, name: 'Dashboard'
       can :create, Ticket
     end
     # Define abilities for the passed in user here. For example:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -59,5 +59,6 @@ ja:
         user_id: 取扱者
         stage_id: 公演
         type_id: チケット種別
+        user_name: 取扱者名
 
   access_denined: 許可されていない操作が実行されました。


### PR DESCRIPTION
- 一般ユーザにDashboardの read権限を追加
- 一般ユーザのチケット登録時に、取扱者名を操作しているユーザ自身の名前を表示するように改善