### PR TITLE
fix: care for args is null

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-  def access_denied(_exception)
+  def access_denied(_exception = nil)
     redirect_to admin_tickets_path, alert: I18n.t('access_denined')
   end
 


### PR DESCRIPTION
アクセス権限がない場合のハンドリング用メソッドに、exceptionが来ないケースに対応