### PR TITLE
データ削除時の不整合を回避する対応と、validationの追加

### DIFF
--- a/app/admin/stages.rb
+++ b/app/admin/stages.rb
@@ -51,10 +51,13 @@ permit_params :performance, :total, :deadline, :end_flag
   controller do
     def destroy
       resource = find_resource
-      return if resource.blank?
-
       resource.destroy
-      flash[:error] = resource.errors.full_messages
+
+      if resource.errors.full_messages.blank?
+        flash[:notice] = '削除しました。'
+      else
+        flash[:error] = resource.errors.full_messages
+      end
       redirect_to action: :index
     end
   end

--- a/app/admin/stages.rb
+++ b/app/admin/stages.rb
@@ -46,6 +46,16 @@ permit_params :performance, :total, :deadline, :end_flag
       row :deadline
       row :end_flag
     end
-end
-  
+  end
+
+  controller do
+    def destroy
+      resource = find_resource
+      return if resource.blank?
+
+      resource.destroy
+      flash[:error] = resource.errors.full_messages
+      redirect_to action: :index
+    end
+  end
 end

--- a/app/admin/types.rb
+++ b/app/admin/types.rb
@@ -53,10 +53,13 @@ end
   controller do
     def destroy
       resource = find_resource
-      return if resource.blank?
-
       resource.destroy
-      flash[:error] = resource.errors.full_messages
+
+      if resource.errors.full_messages.blank?
+        flash[:notice] = '削除しました。'
+      else
+        flash[:error] = resource.errors.full_messages
+      end
       redirect_to action: :index
     end
   end

--- a/app/admin/types.rb
+++ b/app/admin/types.rb
@@ -50,4 +50,14 @@ show title: :kind do
     end
 end
 
+  controller do
+    def destroy
+      resource = find_resource
+      return if resource.blank?
+
+      resource.destroy
+      flash[:error] = resource.errors.full_messages
+      redirect_to action: :index
+    end
+  end
 end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -25,4 +25,17 @@ ActiveAdmin.register User do
     f.actions
   end
 
+  controller do
+    def destroy
+      resource = find_resource
+      resource.destroy
+
+      if resource.errors.full_messages.blank?
+        flash[:notice] = '削除しました。'
+      else
+        flash[:error] = resource.errors.full_messages
+      end
+      redirect_to action: :index
+    end
+  end
 end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -23,7 +23,9 @@ class Stage < ApplicationRecord
   private
 
   def validate_ticket_presence
+    return true if tickets.blank?
+
     errors.add :base, '紐づくチケットが残っているため、削除できません'
-    throw(:abort) if tickets.blank?
+    throw(:abort)
   end
 end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -17,4 +17,13 @@ class Stage < ApplicationRecord
     validates :performance, presence: true #この行を追加しました(2019/1/22)
     validates :total, numericality: { greater_than_or_equal_to: 0 } #この行を追加しました(2019/1/22)
     validates :deadline, presence: true #この行を追加しました(2019/1/22)
+
+  before_destroy :validate_ticket_presence
+
+  private
+
+  def validate_ticket_presence
+    errors.add :base, '紐づくチケットが残っているため、削除できません'
+    throw(:abort) if tickets.blank?
+  end
 end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -12,11 +12,11 @@
 #
 
 class Stage < ApplicationRecord
-    has_many :tickets
-    
-    validates :performance, presence: true #この行を追加しました(2019/1/22)
-    validates :total, numericality: { greater_than_or_equal_to: 0 } #この行を追加しました(2019/1/22)
-    validates :deadline, presence: true #この行を追加しました(2019/1/22)
+  has_many :tickets
+
+  validates :performance, presence: true # この行を追加しました(2019/1/22)
+  validates :total, numericality: { greater_than_or_equal_to: 0 } # この行を追加しました(2019/1/22)
+  validates :deadline, presence: true # この行を追加しました(2019/1/22)
 
   before_destroy :validate_ticket_presence
 

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -25,7 +25,7 @@ class Stage < ApplicationRecord
   def validate_ticket_presence
     return true if tickets.blank?
 
-    errors.add :base, '紐づくチケットが残っているため、削除できません'
+    errors.add :base, 'このレコードを用いてチケットの申込が実施されています。削除する場合は申込済のチケットの情報を変更してください。'
     throw(:abort)
   end
 end

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -24,7 +24,7 @@ class Type < ApplicationRecord
   def validate_ticket_presence
     return true if tickets.blank?
 
-    errors.add :base, '紐づくチケットが残っているため、削除できません'
+    errors.add :base, 'このレコードを用いてチケットの申込が実施されています。削除する場合は申込済のチケットの情報を変更してください。'
     throw(:abort)
   end
 end

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -16,4 +16,15 @@ class Type < ApplicationRecord
     validates :kind, presence: true #この行を追加しました(2019/1/22)
     validates :seat, numericality: { greater_than_or_equal_to: 0 } #この行を追加しました(2019/1/22)
     validates :price, numericality: { greater_than_or_equal_to: 0 }  #この行を追加しました(2019/1/22)
+
+  before_destroy :validate_ticket_presence
+
+  private
+
+  def validate_ticket_presence
+    return true if tickets.blank?
+
+    errors.add :base, '紐づくチケットが残っているため、削除できません'
+    throw(:abort)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,10 +19,13 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, 
          :recoverable, :rememberable, :validatable
-         
+
   has_many :tickets
-  
+
   validates :name, presence: true #この行を追加しました(2019/1/22)
+
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
 
   before_destroy :validate_ticket_presence
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ApplicationRecord
   def validate_ticket_presence
     return true if tickets.blank?
 
-    errors.add :base, '紐づくチケットが残っているため、削除できません'
+    errors.add :base, 'このレコードを用いてチケットの申込が実施されています。削除する場合は申込済のチケットの情報を変更してください。'
     throw(:abort)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,4 +23,15 @@ class User < ApplicationRecord
   has_many :tickets
   
   validates :name, presence: true #この行を追加しました(2019/1/22)
+
+  before_destroy :validate_ticket_presence
+
+  private
+
+  def validate_ticket_presence
+    return true if tickets.blank?
+
+    errors.add :base, '紐づくチケットが残っているため、削除できません'
+    throw(:abort)
+  end
 end


### PR DESCRIPTION
- 公演が削除される際に、チケットがすでにあったら、エラーになるように改善
- ユーザーが削除される際に、チケットがすでにあったら、エラーになるように改善
- チケット種別が削除される際に、チケットがすでにあったら、エラーになるように改善
- ユーザーのemailのフォーマットチェックをするようにvalidationを追加
 