### PR TITLE
カラーの設定をマスタ管理できるようにした

### DIFF
--- a/app/admin/types.rb
+++ b/app/admin/types.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register Type do
 #   permitted
 # end
 
-permit_params :kind, :seat, :price
+permit_params :kind, :seat, :price, :color_id
 
 index do
     selectable_column
@@ -20,7 +20,7 @@ index do
     column :kind
     column :seat
     column :price #この行をを追加しました(2019/1/22)
-    column :color_code
+    column :color_id
     actions
   end
 
@@ -33,7 +33,7 @@ form do |f|
       f.input :kind
       f.input :seat
       f.input :price #この行をを追加しました(2019/1/22)
-      f.input :color_code
+      f.input :color_id, as: :select, collection: Color.pluck(:color_name, :id).to_h #nameを入力必須にしたので、pluck内の『:email』を『:name』に変更しました。(2019/1/22)
     end
     f.actions
   end
@@ -43,7 +43,9 @@ show title: :kind do
       row :kind
       row :seat
       row :price
-      row :color_code
+      row :color_id do |t|
+        t.color.color_name
+      end
     end
 end
 

--- a/app/admin/types.rb
+++ b/app/admin/types.rb
@@ -12,11 +12,7 @@ ActiveAdmin.register Type do
 #   permitted
 # end
 
-
-  
-
 permit_params :kind, :seat, :price
-
 
 index do
     selectable_column
@@ -31,7 +27,6 @@ index do
   filter :kind
   filter :seat
   filter :price #この行をを追加しました(2019/1/22)
-
 
 form do |f|
     f.inputs do

--- a/app/admin/types.rb
+++ b/app/admin/types.rb
@@ -24,6 +24,7 @@ index do
     column :kind
     column :seat
     column :price #この行をを追加しました(2019/1/22)
+    column :color_code
     actions
   end
 
@@ -37,16 +38,17 @@ form do |f|
       f.input :kind
       f.input :seat
       f.input :price #この行をを追加しました(2019/1/22)
+      f.input :color_code
     end
     f.actions
   end
-  
-  
-show title: :kind do  
+
+show title: :kind do
   attributes_table do
       row :kind
       row :seat
       row :price
+      row :color_code
     end
 end
 

--- a/app/controllers/ticket_summary_controller.rb
+++ b/app/controllers/ticket_summary_controller.rb
@@ -6,6 +6,12 @@ class TicketSummaryController < ApplicationController
   def user_summary
     fail if params[:id].to_i != current_user.id
     @user = User.find(params[:id])
-    render json: [Ticket.calc_summary_for_user(current_user)]
+    summary_info =
+      if current_user.admin?
+        Ticket.calc_summary_for_all
+      else
+        [Ticket.calc_summary_for_user(current_user)]
+      end
+    render json: summary_info
   end
 end

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -1,0 +1,2 @@
+class Color < ApplicationRecord
+end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -29,6 +29,14 @@ class Ticket < ApplicationRecord
   validates :count, numericality: { greater_than_or_equal_to: 0 } #この行を追加しました(2019/1/22)
   validates :b_name, presence: true #この行を追加しました(2019/1/22)
 
+  def self.calc_summary_for_all
+    summary = []
+    User.all.each do |u|
+      summary << calc_summary_for_user(u)
+    end
+    summary
+  end
+
   def self.calc_summary_for_user(user)
     summary = {}
     summary[:user_id] = user.id

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -72,7 +72,7 @@ class Ticket < ApplicationRecord
       counts_by_type << {
         type_id: t.id,
         type_name: t.kind,
-        color_code: t.color_code,
+        color_code: t.color.color_code,
         count: tickets.where(type_id: t.id).count
       }
     end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -22,7 +22,7 @@ class Ticket < ApplicationRecord
   accepts_nested_attributes_for :stage
   belongs_to :type
   accepts_nested_attributes_for :type
-  
+
   validates :user_id, presence: true #この行を追加しました(2019/1/22)
   validates :stage_id, presence: true #この行を追加しました(2019/1/22)
   validates :type_id, presence: true #この行を追加しました(2019/1/22)
@@ -64,6 +64,7 @@ class Ticket < ApplicationRecord
       counts_by_type << {
         type_id: t.id,
         type_name: t.kind,
+        color_code: t.color_code,
         count: tickets.where(type_id: t.id).count
       }
     end

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -12,10 +12,12 @@
 
 class Type < ApplicationRecord
     has_many :tickets
+    belongs_to :color
     
     validates :kind, presence: true #この行を追加しました(2019/1/22)
     validates :seat, numericality: { greater_than_or_equal_to: 0 } #この行を追加しました(2019/1/22)
     validates :price, numericality: { greater_than_or_equal_to: 0 }  #この行を追加しました(2019/1/22)
+    validates :color_id, uniqueness: true
 
   before_destroy :validate_ticket_presence
 

--- a/app/views/admin/users/_show_ticket_summary.html.erb
+++ b/app/views/admin/users/_show_ticket_summary.html.erb
@@ -37,7 +37,12 @@
       $("#summary_table").append($("<tr id='" + row_id + "'></tr>"));
       $('#' + row_id).append($("<td></td>").text(data.user_name));
       data.counts_by_stage.forEach( (val) => {
-        $('#' + row_id).append($("<td></td>").text(val.total_seats_count));
+        var content = val.total_seats_count;
+        val.counts_by_type.forEach( (count_by_type) => {
+          content += '<span style="color: ' + count_by_type.color_code + '";>(' + count_by_type.count + ')</span>'
+        });
+
+        $('#' + row_id).append($("<td></td>").html(content));
       });
       $('#' + row_id).append($("<td></td>").text(data.total_counts.summary_total_seats));
     });

--- a/app/views/admin/users/_show_ticket_summary.html.erb
+++ b/app/views/admin/users/_show_ticket_summary.html.erb
@@ -1,18 +1,19 @@
 <div id='js-current_user_id' data-current_user_id='<%= current_user.id %>'></div>
 チケット枚数の見方（凡例）
 <p>
-  <% types = Type.all %>
-  <%= types.count %><% types.each do |t| %><span style="color: <%= t.color_code %>;">(1)</span><% end %>
+  <% types = Type.all.includes(:color) %>
+  <% sample_sum_of_seat = Type.sum(:seat) %>
+  <%= sample_sum_of_seat %><% types.each do |t| %><span style="color: <%= t.color.color_code %>;">(1)</span><% end %>
 </p>
 <% types.each do |t| %>
-  <div style="color: <%= t.color_code %>;">
-    この色は、<%= t.kind %>チケットの販売枚数
+  <div style="color: <%= t.color.color_code%>;">
+    この色は、<%= t.kind %>チケットの販売枚数を表します。1枚の<%= t.kind %>チケットは、席を<%= t.seat %>席分、消費します。
   </div>
 <% end %>
 <p>
 黒色は、各種類のチケットの合計が何席分の売り上げなのかを示す。
 </p>
-上の例では、<%= types.count %> 席埋まっており、内訳が「<% types.each do |t| %><span style="color: <%= t.color_code %>"><%= t.kind %>：1 </span><% end %>」であることをしめす
+上の例では、<%= sample_sum_of_seat %> 席埋まっており、内訳が「<% types.each do |t| %><span style="color: <%= t.color.color_code %>"><%= t.kind %>：1 </span><% end %>」であることをしめす
 <table class='index_table' id='summary_table'>
   <th></th>
   <% Stage.all.each do |stage| %>
@@ -39,7 +40,7 @@
       data.counts_by_stage.forEach( (val) => {
         var content = val.total_seats_count;
         val.counts_by_type.forEach( (count_by_type) => {
-          content += '<span style="color: ' + count_by_type.color_code + '";>(' + count_by_type.count + ')</span>'
+          content += '<span style="color: ' + count_by_type.color.color_code + '";>(' + count_by_type.count + ')</span>'
         });
 
         $('#' + row_id).append($("<td></td>").html(content));

--- a/app/views/admin/users/_show_ticket_summary.html.erb
+++ b/app/views/admin/users/_show_ticket_summary.html.erb
@@ -5,14 +5,14 @@
   <%= types.count %><% types.each do |t| %>(1)<% end %>
 </p>
 <% types.each do |t| %>
-  <div>
+  <div style="color: <%= t.color_code %>;">
     この色は、<%= t.kind %>チケットの販売枚数
   </div>
 <% end %>
 <p>
 この色は、各種類のチケットの合計が何席分の売り上げなのかを示す。
 </p>
-上の例では、<%= types.count %> 席埋まっており、内訳が「<% types.each do |t| %><%= t.kind %>：1 <% end %>」であることをしめす
+上の例では、<%= types.count %> 席埋まっており、内訳が「<% types.each do |t| %><span style="color: <%= t.color_code %>"><%= t.kind %>：1 </span><% end %>」であることをしめす
 <table class='index_table' id='summary_table'>
   <th></th>
   <% Stage.all.each do |stage| %>

--- a/app/views/admin/users/_show_ticket_summary.html.erb
+++ b/app/views/admin/users/_show_ticket_summary.html.erb
@@ -40,7 +40,7 @@
       data.counts_by_stage.forEach( (val) => {
         var content = val.total_seats_count;
         val.counts_by_type.forEach( (count_by_type) => {
-          content += '<span style="color: ' + count_by_type.color.color_code + '";>(' + count_by_type.count + ')</span>'
+          content += '<span style="color: ' + count_by_type.color_code + '";>(' + count_by_type.count + ')</span>'
         });
 
         $('#' + row_id).append($("<td></td>").html(content));

--- a/app/views/admin/users/_show_ticket_summary.html.erb
+++ b/app/views/admin/users/_show_ticket_summary.html.erb
@@ -2,7 +2,7 @@
 チケット枚数の見方（凡例）
 <p>
   <% types = Type.all %>
-  <%= types.count %><% types.each do |t| %>(1)<% end %>
+  <%= types.count %><% types.each do |t| %><span style="color: <%= t.color_code %>;">(1)</span><% end %>
 </p>
 <% types.each do |t| %>
   <div style="color: <%= t.color_code %>;">
@@ -10,7 +10,7 @@
   </div>
 <% end %>
 <p>
-この色は、各種類のチケットの合計が何席分の売り上げなのかを示す。
+黒色は、各種類のチケットの合計が何席分の売り上げなのかを示す。
 </p>
 上の例では、<%= types.count %> 席埋まっており、内訳が「<% types.each do |t| %><span style="color: <%= t.color_code %>"><%= t.kind %>：1 </span><% end %>」であることをしめす
 <table class='index_table' id='summary_table'>

--- a/db/migrate/20190728023716_add_color_code_to_type.rb
+++ b/db/migrate/20190728023716_add_color_code_to_type.rb
@@ -1,0 +1,5 @@
+class AddColorCodeToType < ActiveRecord::Migration[5.1]
+  def change
+    add_column :types, :color_code, :string, unique: true
+  end
+end

--- a/db/migrate/20190730111448_create_colors.rb
+++ b/db/migrate/20190730111448_create_colors.rb
@@ -1,0 +1,10 @@
+class CreateColors < ActiveRecord::Migration[5.1]
+  def change
+    create_table :colors do |t|
+      t.string :color_code, uniq: true, null: false
+      t.string :color_name, uniq: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190730112200_rename_color_code_column_to_types.rb
+++ b/db/migrate/20190730112200_rename_color_code_column_to_types.rb
@@ -1,0 +1,6 @@
+class RenameColorCodeColumnToTypes < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :types, :color_code, :color_id
+    change_column :types, :color_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190728023716) do
+ActiveRecord::Schema.define(version: 20190730112200) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"
@@ -24,6 +24,13 @@ ActiveRecord::Schema.define(version: 20190728023716) do
     t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
     t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
     t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"
+  end
+
+  create_table "colors", force: :cascade do |t|
+    t.string "color_code", null: false
+    t.string "color_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "registers", force: :cascade do |t|
@@ -75,7 +82,7 @@ ActiveRecord::Schema.define(version: 20190728023716) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "price"
-    t.string "color_code"
+    t.integer "color_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190407083724) do
+ActiveRecord::Schema.define(version: 20190728023716) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 20190407083724) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "price"
+    t.string "color_code"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,11 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+Color.create!(color_code: '#FF0000', color_name: 'red')
+Color.create!(color_code: '#00FF00', color_name: 'green')
+Color.create!(color_code: '#0000FF', color_name: 'blue')
+
 User.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password', name: '0') if Rails.env.development?
 User.create!(email: 'puente.japan@gmail.com', password: 'orangeseed69', password_confirmation: 'orangeseed69', name: '1') if Rails.env.development?
 User.create!(email: 'puente.japan2@gmail.com', password: 'orangeseed69', password_confirmation: 'orangeseed69', name: '2') if Rails.env.development?


### PR DESCRIPTION
- db/seed.rbのColor.create!を適宜増やしていただくようお願いいたします。(sampleでは、blue,red,greenにしています)
- colorsテーブルを作成しておりますので、 `bundle exec rake db:migrate` を実行してください。
- seed.rbをへんこうしておりますので、 `bundle exec rake db:seed RAILS_ENV=development` を実行してください
- チケット種別を編集するときに、colorをプルダウンで選べるようになっています。また重複は、エラーメッセージをひょうじするようにしています。