### PR TITLE
組み合わせページの実装

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -8,6 +8,4 @@ class LinksController < ApplicationController
   def destroy
     Link.find(params[:id]).destroy
   end
-
-  private
 end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class LinksController < ApplicationController
+  def create
+    Link.new(type_id: params[:type_id], stage_id: params[:stage_id]).save
+  end
+
+  def destroy
+    Link.find(params[:id]).destroy
+  end
+
+  private
+end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -2,10 +2,12 @@
 
 class LinksController < ApplicationController
   def create
-    Link.new(type_id: params[:type_id], stage_id: params[:stage_id]).save
+    @link = Link.new(type_id: params[:type_id], stage_id: params[:stage_id])
+    @link.save
   end
 
   def destroy
-    Link.find(params[:id]).destroy
+    @link = Link.find(params[:id])
+    @link.destroy
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,10 +6,11 @@ class Ability
     if user.admin?
       can :manage, :all
     else
+      can :read, ActiveAdmin::Page, name: 'Dashboard'
       # Ticketは、自身のものだけは管理できる
       can :manage, Ticket, user: user
-      can :read, ActiveAdmin::Page, name: 'Dashboard'
       can :create, Ticket
+      cannot :update, Ticket, id: Ticket.join_links.pluck(:id) # linkテーブルに紐づくticketは更新できない
     end
     # Define abilities for the passed in user here. For example:
     #

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -22,6 +22,17 @@ class Ticket < ApplicationRecord
   accepts_nested_attributes_for :stage
   belongs_to :type
   accepts_nested_attributes_for :type
+  scope :join_links, -> {
+    joins(<<-SQL
+    INNER JOIN
+      links
+      ON
+        links.stage_id = tickets.stage_id
+        AND
+        links.type_id = tickets.type_id
+    SQL
+    )
+  }
 
   validates :user_id, presence: true #この行を追加しました(2019/1/22)
   validates :stage_id, presence: true #この行を追加しました(2019/1/22)

--- a/app/views/admin/tickets/_edit_ticket_links.html.erb
+++ b/app/views/admin/tickets/_edit_ticket_links.html.erb
@@ -1,4 +1,12 @@
 <div id='js-current_user_id' data-current_user_id='<%= current_user.id %>'></div>
+<p>
+『-』(ハイフン)がついている項目は、『販売終了フラグ』が ON のため、一般取扱者はチケットの操作ができません。
+一般取扱者が操作をするためには、『販売終了フラグ』を『OFF』にしてください。
+</p>
+<p>
+☑がついている項目は、一般取扱者はチケットの操作ができません。
+一般取扱者が操作をするためには、☑を□にしてください。
+</p>
 <table class='index_table' id='summary_table' style="text-align: center">
   <th></th>
   <% Type.kind_order.each do |type| %>

--- a/app/views/admin/tickets/_edit_ticket_links.html.erb
+++ b/app/views/admin/tickets/_edit_ticket_links.html.erb
@@ -1,5 +1,5 @@
 <div id='js-current_user_id' data-current_user_id='<%= current_user.id %>'></div>
-<table class='index_table' id='summary_table'>
+<table class='index_table' id='summary_table' style="text-align: center">
   <th></th>
   <% Type.kind_order.each do |type| %>
     <th><%= type.kind %></th>

--- a/app/views/admin/tickets/_edit_ticket_links.html.erb
+++ b/app/views/admin/tickets/_edit_ticket_links.html.erb
@@ -14,11 +14,13 @@
           <% else %>
             <% if link = stage.links.find_by(type_id: type.id) %>
               <input type='checkbox' checked value='1' class='js-link-post'
+                style="cursor: pointer"
                 data-url='<%=link_path(link.id) %>'
                 data-method='DELETE'
               />
             <% else %>
               <input type='checkbox' value='1' class='js-link-post'
+                style="cursor: pointer"
                 data-url='<%=links_path %>'
                 data-stage_id='<%= stage.id%>'
                 data-type_id='<%= type.id%>'

--- a/app/views/admin/tickets/_edit_ticket_links.html.erb
+++ b/app/views/admin/tickets/_edit_ticket_links.html.erb
@@ -9,13 +9,40 @@
       <td><%= stage.performance  %></td>
       <% Type.kind_order.each do |type| %>
         <td>
-          <% if stage.links.find_by(type_id: type.id) %>
-            TODO:チェックボックスをONで表示する
+          <% if stage.end_flag? %>
+            -
           <% else %>
-            TODO:チェックボックスをOFFで表示する
+            <% if link = stage.links.find_by(type_id: type.id) %>
+              <input type='checkbox' checked value='1' class='js-link-post'
+                data-url='<%=link_path(link.id) %>'
+                data-method='DELETE'
+              />
+            <% else %>
+              <input type='checkbox' value='1' class='js-link-post'
+                data-url='<%=links_path %>'
+                data-stage_id='<%= stage.id%>'
+                data-type_id='<%= type.id%>'
+                data-method='POST'
+              />
+            <% end %>
           <% end %>
         </td>
       <% end %>
     </tr>
   <% end %>
 </table>
+<script>
+  $('.js-link-post').click(function() {
+  var checked;
+  url = $(this).data('url');
+  method = $(this).data('method');
+  $.ajax({
+      type: method,
+      url: url,
+    data: {
+      stage_id: $(this).data('type_id'),
+      type_id: $(this).data('stage_id')
+    }
+   });
+  });
+</script>

--- a/app/views/admin/tickets/_edit_ticket_links.html.erb
+++ b/app/views/admin/tickets/_edit_ticket_links.html.erb
@@ -20,21 +20,14 @@
           <% if stage.end_flag? %>
             -
           <% else %>
-            <% if link = stage.links.find_by(type_id: type.id) %>
-              <input type='checkbox' checked value='1' class='js-link-post'
-                style="cursor: pointer"
-                data-url='<%=link_path(link.id) %>'
-                data-method='DELETE'
-              />
-            <% else %>
-              <input type='checkbox' value='1' class='js-link-post'
-                style="cursor: pointer"
-                data-url='<%=links_path %>'
-                data-stage_id='<%= stage.id%>'
-                data-type_id='<%= type.id%>'
-                data-method='POST'
-              />
-            <% end %>
+            <span id="chk_stage<%= stage.id %>_type<%= type.id %>">
+              <% if link = stage.links.find_by(type_id: type.id) %>
+                <%= render '/links/link_destroy_check_box', link: link %>
+              </span>
+              <% else %>
+                <%= render '/links/link_create_check_box', stage_id: stage.id, type_id: type.id %>
+              <% end %>
+            </span>
           <% end %>
         </td>
       <% end %>
@@ -42,17 +35,14 @@
   <% end %>
 </table>
 <script>
-  $('.js-link-post').click(function() {
-  var checked;
-  url = $(this).data('url');
-  method = $(this).data('method');
-  $.ajax({
-      type: method,
-      url: url,
-    data: {
-      stage_id: $(this).data('type_id'),
-      type_id: $(this).data('stage_id')
-    }
-   });
-  });
+  function link_post(url, method, type_id, stage_id) {
+    $.ajax({
+        type: method,
+        url: url,
+      data: {
+        stage_id: stage_id,
+        type_id: type_id
+      }
+    });
+  }
 </script>

--- a/app/views/links/_link_create_check_box.html.erb
+++ b/app/views/links/_link_create_check_box.html.erb
@@ -1,0 +1,6 @@
+<% # stage_id: required %>
+<% # type_id: required %>
+<input type='checkbox' value='1' class='js-link-post'
+  style="cursor: pointer"
+  onClick="link_post('<%=links_path %>', 'POST','<%= type_id %>', '<%= stage_id %>');"
+/>

--- a/app/views/links/_link_destroy_check_box.html.erb
+++ b/app/views/links/_link_destroy_check_box.html.erb
@@ -1,0 +1,5 @@
+<% # link: required %>
+<input type='checkbox' checked value='1' class='js-link-post'
+  style="cursor: pointer"
+  onClick="link_post('<%=link_path(link.id) %>', 'DELETE');"
+/>

--- a/app/views/links/create.js.erb
+++ b/app/views/links/create.js.erb
@@ -1,0 +1,1 @@
+console.log('created');

--- a/app/views/links/create.js.erb
+++ b/app/views/links/create.js.erb
@@ -1,1 +1,4 @@
 console.log('created');
+$('#chk_stage<%= @link.stage_id %>_type<%= @link.type_id %>').html(
+  "<%= j(render '/links/link_destroy_check_box', link: @link) %>"
+);

--- a/app/views/links/destroy.js.erb
+++ b/app/views/links/destroy.js.erb
@@ -1,0 +1,1 @@
+console.log('destroy');

--- a/app/views/links/destroy.js.erb
+++ b/app/views/links/destroy.js.erb
@@ -1,1 +1,4 @@
 console.log('destroy');
+$('#chk_stage<%= @link.stage_id %>_type<%= @link.type_id %>').html(
+  "<%= j(render '/links/link_create_check_box', stage_id: @link.stage_id, type_id: @link.type_id) %>"
+);

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -218,7 +218,7 @@ ActiveAdmin.setup do |config|
   config.namespace :admin do |admin|
     admin.build_menu do |menu|
       menu.add label: '集計', url: '/admin/users/show_ticket_summary', html_options: { }, priority: 1
-      menu.add label: '公演とチケットの組み合わせ', url: '/admin/tickets/edit_ticket_links', html_options: { }, priority: 2
+      menu.add label: '公演とチケットの組み合わせ', url: '/admin/tickets/edit_ticket_links', html_options: { }, priority: 2, if: proc { current_user.admin? }
     end
   end
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :links, only: %i[create destroy]
+
   devise_for :users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self) rescue ActiveAdmin::DatabaseHitDuringLoad
   get 'welcome/index'


### PR DESCRIPTION
- 組み合わせページを操作することで、linkテーブルの登録・削除ができること
- linkテーブルのレコードが作られた場合、一般ユーザでは、linkテーブルと同じstage_id,type_idをもっているチケットの編集はできなくなること

次回以降とさせていただきたい実装部分
- お客様がWEBから予約する時にに、linkテーブルに存在するものを選んだ場合にエラーになること
- 一般ユーザが管理画面から予約する時に、linkテーブルに存在するものを選んだ場合にエラーになること