### PR TITLE
Linkを使ったチェックの修正などを含む、Webからの申し込みページの機能追加や不具合修正

### DIFF
--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -7,7 +7,7 @@ class Register < ApplicationRecord
 
   validates :stage_id, presence: true
   validates :type_id, presence: true
-  validates :count, numericality: { greater_than_or_equal_to: 0 }
+  validates :count, numericality: { greater_than: 0 }
   validates :b_name, presence: true
 
   validate :not_over_remain_count_of_seat

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -5,6 +5,11 @@ class Register < ApplicationRecord
   belongs_to :type
   enum state: { init: 0, confirmed: 10 }
 
+  validates :stage_id, presence: true
+  validates :type_id, presence: true
+  validates :count, numericality: { greater_than_or_equal_to: 0 }
+  validates :b_name, presence: true
+
   validate :not_over_remain_count_of_seat
 
   validate :check_conbitation_of_type_and_stage, unless: -> { validation_context == :admin }

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -7,6 +7,7 @@ class Register < ApplicationRecord
 
   validate :not_over_remain_count_of_seat
 
+  validate :check_conbitation_of_type_and_stage, unless: -> { validation_context == :admin }
   def generate_ticket
     ticket = Ticket.create(
       user_id: user_id,
@@ -28,5 +29,11 @@ class Register < ApplicationRecord
     return if stage.remain_count_of_seat >= type.seat * count
 
     errors.add(:count, ': 残りの座席数を超えるため予約できません')
+  end
+
+  def check_conbitation_of_type_and_stage
+    return unless Link.find_by(stage_id: stage_id, type_id: type_id)
+
+    errors.add(:stage_and_type, '：選択いただいた『開演日時 / チケット種別』の組み合わせでは予約を承ることができません。')
   end
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -26,7 +26,7 @@ class Ticket < ApplicationRecord
   validates :user_id, presence: true #この行を追加しました(2019/1/22)
   validates :stage_id, presence: true #この行を追加しました(2019/1/22)
   validates :type_id, presence: true #この行を追加しました(2019/1/22)
-  validates :count, numericality: { greater_than_or_equal_to: 0 } #この行を追加しました(2019/1/22)
+  validates :count, numericality: { greater_than: 0 } #この行を追加しました(2019/1/22)
   validates :b_name, presence: true #この行を追加しました(2019/1/22)
 
   after_create :notice_mail_for_create_ticket

--- a/app/views/registers/_form.html.erb
+++ b/app/views/registers/_form.html.erb
@@ -34,7 +34,7 @@
 
   <div class="form-group">
     <%= form.label :b_name %>
-    <%= form.text_field :b_name, id: :register_b_name, class: 'form-control' %>
+    <%= form.text_field :b_name, id: :register_b_name, class: 'form-control', required: :required %>
   </div>
 
   <div class="form-group">

--- a/app/views/registers/_form.html.erb
+++ b/app/views/registers/_form.html.erb
@@ -19,17 +19,17 @@
 
   <div class="form-group">
     <%= form.label :stage%>
-    <%= form.select :stage_id, Stage.on_sale.map { |t| [t.performance, t.id]}, {include_blank: true}, class: 'form-control' %>
+    <%= form.select :stage_id, Stage.on_sale.map { |t| [t.performance, t.id]}, {include_blank: true}, class: 'form-control', required: :required %>
   </div>
 
   <div class="form-group">
     <%= form.label :type%>
-    <%= form.select :type_id, Type.all.map { |t| [t.kind, t.id]}, {include_blank: true},  class: 'form-control' %>
+    <%= form.select :type_id, Type.all.map { |t| [t.kind, t.id]}, {include_blank: true},  class: 'form-control', required: :required  %>
   </div>
 
   <div class="form-group">
     <%= form.label :count %>
-    <%= form.number_field :count, id: :register_count, class: 'form-control' %>
+    <%= form.number_field :count, id: :register_count, class: 'form-control', required: :required  %>
   </div>
 
   <div class="form-group">

--- a/app/views/registers/show_confirm.html.erb
+++ b/app/views/registers/show_confirm.html.erb
@@ -14,16 +14,6 @@
   </div>
 
   <div class="field">
-    <%= form.label :b_name %>
-    <%= form.text_field :b_name, id: :register_b_name, disabled: true, class: 'form-control' %>
-  </div>
-
-  <div class="field">
-    <%= form.label :b_email %>
-    <%= form.text_field :b_email, id: :register_b_email, disabled: true, class: 'form-control' %>
-  </div>
-
-  <div class="field">
     <%= form.label :stage_id %>
     <%= form.select :stage_id, Stage.all.map { |t| [t.performance, t.id]}, {}, disabled: true, class: 'form-control' %>
   </div>
@@ -31,6 +21,21 @@
   <div class="field">
     <%= form.label :type_id %>
     <%= form.select :type_id, Type.all.map { |t| [t.kind, t.id]}, {}, disabled: true, class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :count %>
+    <%= form.number_field :count, id: :register_count, disabled: true, class: 'form-control', required: :required  %>
+  </div>
+
+  <div class="field">
+    <%= form.label :b_name %>
+    <%= form.text_field :b_name, id: :register_b_name, disabled: true, class: 'form-control' %>
+  </div>
+
+  <div class="field">
+    <%= form.label :b_email %>
+    <%= form.text_field :b_email, id: :register_b_email, disabled: true, class: 'form-control' %>
   </div>
 
   <div class="field">

--- a/app/views/registers/show_confirm.html.erb
+++ b/app/views/registers/show_confirm.html.erb
@@ -14,12 +14,12 @@
   </div>
 
   <div class="field">
-    <%= form.label :stage_id %>
+    <%= form.label :stage%>
     <%= form.select :stage_id, Stage.all.map { |t| [t.performance, t.id]}, {}, disabled: true, class: 'form-control' %>
   </div>
 
   <div class="field">
-    <%= form.label :type_id %>
+    <%= form.label :type%>
     <%= form.select :type_id, Type.all.map { |t| [t.kind, t.id]}, {}, disabled: true, class: 'form-control' %>
   </div>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -67,6 +67,7 @@ ja:
         b_email: お客様のメールアドレス
         stage: 公演
         type: チケット種別
+        stage_and_type: 公演とチケット種別の組み合わせ
         comment: ひとこと
 
   access_denined: 許可されていない操作が実行されました。


### PR DESCRIPTION
> ・『組み合わせテーブル』が『ON』の公演でも予約可能。※ページ『お申込み確認』に移行可能という意味です。
エラーメッセージを表示するように実装入れました。
とりあえず表示させているエラーメッセージ：「公演とチケット種別の組み合わせ：選択いただいた『開演日時 / チケット種別』の組み合わせでは予約を承ることができません。」(config/locales/ja.yml に文言を入れていますので、適宜修正していただいて構いません)

・ページ『お申し込み内容確認』でボタン『確認』が押下しても、反応なし。
こちらについては、上記対応によりそもそも行けなくなりましたが、
例えば、Webから申し込みしている人が、確認画面まで進む -> 条件に該当するLinkテーブルのレコードが登録される -> エラーメッセージが表示されるようになっていると思います。

> ・ページ『お申し込み内容確認』でボタン『修正』が押下したときに、エラーが表示される場合がある。※添付ファイル２を参照ください。出ないときもあるため、条件は不明。
こちらは、WEB予約ページ側のvalidationが、ticketではやっているが、registerではやっていないことが原因でしたので、register側のチェックを追加いたしました。
具体的には、ticketでやっている、以下のチェックを追加することで対処いたしました。
「stage_id必須」「type_id必須」「countが0より大きい数値(※実装が0以上になっていましたが、0はチケット枚数としては不適切と判断しましたので、1以上が入力されるように修正しています)」「お客様の名前：必須」

> 『組み合わせテーブル』対応と関係ないとは思うのですが、『WEBからの予約ページ』の最初のページとページ『お申し込み内容確認』では、表示される項目とその順番が異なるので統一したいです。
すみません、並び順がおかしかったのを、countがひょうじされていなかったのを修正いたしました。

> また、ページ『お申し込み内容確認』で項目名が英語になっているところを日本語にしたいです。※添付ファイル１、３を参照ください。
こちらの不具合も合わせて修正させていただきました。

